### PR TITLE
add additional requirements to python 3.9-3.12 requirements.txt

### DIFF
--- a/requirements/prod_py39_to_py312.txt
+++ b/requirements/prod_py39_to_py312.txt
@@ -21,6 +21,11 @@ marshmallow==3.20.1
 packaging==23.2
 psycopg2==2.9.9
 PyJWT==2.8.0
+pycparser==2.20
+python-dateutil==2.8.1
+python-dotenv==0.12.0
+python-editor==1.0.4
+simplejson==3.17.0
 six==1.16.0
 SQLAlchemy==2.0.22
 typing_extensions==4.8.0
@@ -28,3 +33,4 @@ unicode-slugify==0.1.5
 Unidecode==1.3.7
 webargs==8.3.0
 Werkzeug==3.0.0
+requests==2.28.1


### PR DESCRIPTION
There were some requirements missing from the dev requirments.txt file which is what was originally used. 