### PR TITLE
[python] fix requirements conflicts

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -33,5 +33,5 @@ unicode-slugify==0.1.5
 Unidecode==1.3.7
 webargs==8.3.0
 Werkzeug==3.0.0
-requests==2.28.1
+requests==2.31.0
 urllib3==2.2.1


### PR DESCRIPTION
Reliability environment has a startup error related to a requests and urlib3 conflcit:

```
INFO: pip is looking at multiple versions of flask-migrate to determine which version is compatible with other requirements. This could take a while.
INFO: pip is looking at multiple versions of alembic to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r requirements/prod.txt (line 36) and urllib3==2.2.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested urllib3==2.2.1
    requests 2.28.1 depends on urllib3<1.27 and >=1.21.1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts

[notice] A new release of pip is available: 23.0.1 -> 24.0

....

[notice] A new release of pip is available: 23.0.1 -> 24.0
[notice] To update, run: pip install --upgrade pip
./run.sh: line 31: flask: command not found
./run.sh: line 32: flask: command not found
./run.sh: line 33: flask: command not found
```