### PR TITLE
Add re functions to leak tests

### DIFF
--- a/conduit/security/views.py
+++ b/conduit/security/views.py
@@ -7,18 +7,20 @@ Security views work to validate the below Datadog products in real-world scenari
 import json
 import os
 import random
+import re
 import subprocess
 
 # See comment below on the (disabled) SSRF test
 # import requests
-# import urllib3
+import urllib3
 from flask import Blueprint, Response, request
 
 from flask_apispec import use_kwargs
 from flask_jwt_extended import jwt_required
 from marshmallow import fields
-from conduit.articles.models import Article
+from conduit.articles.models import Article, Tags
 from conduit.articles.serializers import articles_schema
+from conduit.user.models import User
 
 try:
     from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
@@ -29,12 +31,7 @@ except ImportError:
 
 blueprint = Blueprint("security", __name__)
 
-
-@blueprint.route("/iast/propagation", methods=["GET"])
-def iast_propagation():
-    """Application Vulnerability Management has 3 key concepts: origins, propagation and sink points (vulnerabilities)
-    this view validates some origins, check the propagation of different strings and multiple vulnerabilities
-    """
+def _iast_propagation():
     # Origin 1: string1
     origin_string1 = request.args.get("string1")
     # Origin 2: password
@@ -71,12 +68,12 @@ def iast_propagation():
     # Note: this seems to have a leak on ddtrace/contrib/requests/connection.py on the line:
     # with tracer.trace(operation_name, service=service, resource=f"{method} {path}", span_type=SpanTypes.HTTP) as span:
     # Since this hides other potential leaks caused by our aspects, we disabled this test
-    # try:
-    #     # SSRF vulnerability
-    #     # requests.get("http://" + string9)
-    #      urllib3.request("GET", "http://" + string9)
-    # except Exception:
-    #     pass
+    try:
+        # SSRF vulnerability
+        # requests.get("http://" + string9)
+         urllib3.request("GET", "http://" + string9)
+    except Exception:
+        pass
 
         # Weak Randomness vulnerability
     _ = random.randint(1, 10)
@@ -90,25 +87,57 @@ def iast_propagation():
     string19 = os.path.normcase(string18)  # 1 propagation range: notainted_HIROOT1234-HIROOT123_notainted
     string20 = os.path.splitdrive(string19)[1]  # 1 propagation range: notainted_HIROOT1234-HIROOT123_notainted
 
-    string20 += "_extend"
+    re_slash = re.compile(r"[_.][a-zA-Z]*")
+    string21 = re_slash.findall(string20)[0]  # 1 propagation: '_HIROOT
+
+    re_match = re.compile(r"(\w+)", re.IGNORECASE)
+    re_match_result = re_match.match(string21)  # 1 propagation: 'HIROOT
+
+    string22 = re_match_result.group(0)  # 1 propagation: '_HIROOT
+    # string22 = re_match_result.groups()[0]
+    tmp_str = "DDDD"
+    string23 = tmp_str + string22  # 1 propagation: 'DDDD_HIROOT
+
+    re_match = re.compile(r"(\w+)(_+)(\w+)", re.IGNORECASE)
+    re_match_result = re_match.search(string23)
+    string24 = re_match_result.expand(r"DDD_\3")  # 1 propagation: 'DDD_HIROOT
+
+    re_split = re.compile(r"[_.][a-zA-Z]*", re.IGNORECASE)
+    re_split_result = re_split.split(string24)
+
+    string25 = re_split_result[0] + " EEE"
+    string26 = re.sub(r" EEE", "_OOO", string25, re.IGNORECASE)
+    string27 = re.subn(r"OOO", "III", string26, re.IGNORECASE)[0]
+
+    tmp_str2 = "_extend"
+    string27 += tmp_str2
 
     # validates default output and IAST output
-    expected = "notainted_HIROOT1234-HIROOT123_notainted_extend"
-    assert string20 == expected, f"Error, string 18 is\n{string20}\nExpected:\n{expected}"
+    expected = "DDD_III_extend"
+    assert string27 == expected, f"Error, string27 is\n{string27}\nExpected:\n{expected}"
 
+    return string27
+
+@blueprint.route("/iast/propagation", methods=["GET"])
+def iast_propagation():
+    """Application Vulnerability Management has 3 key concepts: origins, propagation and sink points (vulnerabilities)
+    this view validates some origins, check the propagation of different strings and multiple vulnerabilities
+    """
+
+    result = _iast_propagation()
     # Insecure Cookie vulnerability
     resp = Response(
         json.dumps(
             {
-                "string_result": string20,
-                "tainted": is_pyobject_tainted(string20),
-                "ranges": str(get_tainted_ranges(string20)),
+                "string_result": result,
+                "tainted": is_pyobject_tainted(result),
+                "ranges": str(get_tainted_ranges(result)),
             }
         )
     )
     resp.set_cookie("insecure", "cookie", secure=False, httponly=False, samesite="None")
-    resp.headers["Vary"] = string20
-    resp.headers['Header-Injection'] = string20
+    resp.headers["Vary"] = result
+    resp.headers['Header-Injection'] = result
 
     return resp
 
@@ -136,66 +165,10 @@ def get_articles(tag=None, author=None, favorited=None, limit=20, offset=0):
 
     resp = Response(articles_schema.dump(res.offset(offset).limit(limit).all()))
 
-    # Second part, same as method above
-    # Origin 1: string1
-    origin_string1 = request.args.get("string1")
-    # Origin 2: password
-    tainted_string_2 = request.args.get("password")
-
-    string1 = str(origin_string1)  # String with 1 propagation range
-    string2 = str(tainted_string_2)  # String with 1 propagation range
-
-    string3 = string1 + string2  # 2 propagation ranges: hiroot1234
-    string4 = "-".join([string3, string3, string3])  # 6 propagation ranges: hiroot1234-hiroot1234-hiroot1234
-    string5 = string4[0:20]  # 1 propagation range: hiroot1234-hiroot123
-    string6 = string5.title()  # 1 propagation range: Hiroot1234-Hiroot123
-    string7 = string6.upper()  # 1 propagation range: HIROOT1234-HIROOT123
-    string8 = "%s_notainted" % string7  # 1 propagation range: HIROOT1234-HIROOT123_notainted
-    string9 = "notainted_{}".format(string8)  # 1 propagation range: notainted_HIROOT1234-HIROOT123_notainted
-    string10 = "nottainted\n" + string9  # 2 propagation ranges: notainted\nnotainted_HIROOT1234-HIROOT123_notainted
-    string11 = string10.splitlines()[1]  # 1 propagation range: notainted_HIROOT1234-HIROOT123_notainted
-    string12 = string11 + "_notainted"  # 1 propagation range: notainted_HIROOT1234-HIROOT123_notainted_notainted
-    string13 = string12.rsplit("_", 1)[0]  # 1 propagation range: notainted_HIROOT1234-HIROOT123_notainted
-
-    try:
-        # Path traversal vulnerability
-        m = open("/" + string13 + ".txt")
-        _ = m.read()
-    except Exception:
-        pass
-
-    try:
-        # Command Injection vulnerability
-        _ = subprocess.Popen("ls " + string9)
-    except Exception:
-        pass
-
-    # Note: this seems to have a leak on ddtrace/contrib/requests/connection.py on the line:
-    # with tracer.trace(operation_name, service=service, resource=f"{method} {path}", span_type=SpanTypes.HTTP) as span:
-    # Since this hides other potential leaks caused by our aspects, we disabled this test
-    # try:
-    #     # SSRF vulnerability
-    #     # requests.get("http://" + string9)
-    #      urllib3.request("GET", "http://" + string9)
-    # except Exception:
-    #     pass
-
-        # Weak Randomness vulnerability
-    _ = random.randint(1, 10)
-
-    # os path propagation
-    string14 = os.path.join(string13, "a") # 1 propagation range: notainted_HIROOT1234-HIROOT123_notainted/a
-    string15 = os.path.split(string14)[0] # 1 propagation range: notainted_HIROOT1234-HIROOT123_notainted
-    string16 = os.path.dirname(string15 + "/" + "foobar")  # 1 propagation range: notainted_HIROOT1234-HIROOT123_notainted
-    string17 = os.path.basename("/foobar/" + string16)  # 1 propagation range: notainted_HIROOT1234-HIROOT123_notainted
-    string18 = os.path.splitext(string17 + ".jpg")[0]  # 1 propagation range: notainted_HIROOT1234-HIROOT123_notainted
-    string19 = os.path.normcase(string18)  # 1 propagation range: notainted_HIROOT1234-HIROOT123_notainted
-    string20 = os.path.splitdrive(string19)[1]  # 1 propagation range: notainted_HIROOT1234-HIROOT123_notainted
-
-    string20 += "_extend"
+    result = _iast_propagation()
 
     resp.set_cookie("insecure", "cookie", secure=False, httponly=False, samesite="None")
-    resp.headers["Vary"] = string20
-    resp.headers['Header-Injection'] = string20
+    resp.headers["Vary"] = result
+    resp.headers['Header-Injection'] = result
 
     return resp


### PR DESCRIPTION
- Add re functions to iast propagation view, based on: https://github.com/DataDog/dd-trace-py/pull/10698
- Refactor: move common code of the `iast/propagation` and `iast/articles` views
- Fix potencial import error introduced in https://github.com/DataDog/flask-realworld-example-app/pull/19